### PR TITLE
Add detect_os for work on MacOS and Linux and more

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -29,6 +29,7 @@ generate_juniper_routes() {
     while read -r prefix; do
         echo "set groups TWITTER-BLOCK routing-options static route $prefix discard" >> "$output_file"
     done < tmp_prefixes.txt
+    echo "set apply-groups TWITTER-BLOCK" >> "$output_file" # Adiciona apply-groups para Juniper
 }
 
 generate_nokia_routes() {

--- a/run.sh
+++ b/run.sh
@@ -5,11 +5,11 @@ detect_os() {
     case "$(uname -s)" in
         Darwin)
             # macOS
-            SED_INLINE="sed -i '' -e"
+            SED_INLINE="sed -i ''"
             ;;
         Linux)
             # Linux
-            SED_INLINE="sed -i -e"
+            SED_INLINE="sed -i"
             ;;
         *)
             echo "Sistema operacional não suportado!"
@@ -56,42 +56,6 @@ generate_vyos_routes() {
     done < tmp_prefixes.txt
 }
 
-# Funções para adicionar comandos de remoção
-add_cisco_removal() {
-    while read -r prefix; do
-        echo "no ip route $prefix Null0" >> "$output_file"
-    done < tmp_prefixes.txt
-}
-
-add_juniper_removal() {
-    echo "delete groups TWITTER-BLOCK" >> "$output_file"
-    echo "delete apply-groups TWITTER-BLOCK" >> "$output_file"
-}
-
-add_nokia_removal() {
-    while read -r prefix; do
-        echo "no configure router static-route $prefix blackhole" >> "$output_file"
-    done < tmp_prefixes.txt
-}
-
-add_huawei_removal() {
-    while read -r prefix; do
-        echo "undo ip route-static $prefix NULL0" >> "$output_file"
-    done < tmp_prefixes.txt
-}
-
-add_mikrotik_removal() {
-    while read -r prefix; do
-        echo "/ip route remove dst-address=$prefix" >> "$output_file"
-    done < tmp_prefixes.txt
-}
-
-add_vyos_removal() {
-    while read -r prefix; do
-        echo "delete protocols static route $prefix" >> "$output_file"
-    done < tmp_prefixes.txt
-}
-
 # Lista de ASNs
 asns=("63179" "54888" "35995" "13414")
 
@@ -108,10 +72,9 @@ echo "5 - Mikrotik"
 echo "6 - VyOS"
 read -p "Escolha uma opção (1-6): " choice
 
-# Define os arquivos de saída
+# Define o arquivo de saída
 output_file="static_routes.txt"
-temp_file="juniper_temp.txt"
-rm -rf "$output_file" "$temp_file"
+rm -f "$output_file"
 
 # Limpa o arquivo de saída
 > "$output_file"
@@ -147,61 +110,12 @@ for asn in "${asns[@]}"; do
             ;;
     esac
 
-    # Executa o sed para remover as linhas específicas ao ASN atual
+    # Remove as linhas específicas ao ASN atual do arquivo de saída
     $SED_INLINE "s/ip prefix-list prefix_list_${asn} permit//g" "$output_file"
-    
+
     # Remove o arquivo temporário
     rm -f tmp_prefixes.txt
 done
-
-# Adiciona os comandos de remoção ao final do arquivo
-case $choice in
-    1)
-        echo "# Commands to remove Cisco routes" >> "$output_file"
-        for asn in "${asns[@]}"; do
-            bgpq4 -4 -m 24 -l prefix_list_$asn AS$asn | grep -v '^no ip prefix-list' > tmp_prefixes.txt
-            add_cisco_removal
-            rm -f tmp_prefixes.txt
-        done
-        ;;
-    2)
-        echo "set apply-groups TWITTER-BLOCK" >> "$output_file"
-        echo "# Commands to remove Juniper routes" >> "$output_file"
-        add_juniper_removal
-        ;;
-    3)
-        echo "# Commands to remove Nokia routes" >> "$output_file"
-        for asn in "${asns[@]}"; do
-            bgpq4 -4 -m 24 -l prefix_list_$asn AS$asn | grep -v '^no ip prefix-list' > tmp_prefixes.txt
-            add_nokia_removal
-            rm -f tmp_prefixes.txt
-        done
-        ;;
-    4)
-        echo "# Commands to remove Huawei routes" >> "$output_file"
-        for asn in "${asns[@]}"; do
-            bgpq4 -4 -m 24 -l prefix_list_$asn AS$asn | grep -v '^no ip prefix-list' > tmp_prefixes.txt
-            add_huawei_removal
-            rm -f tmp_prefixes.txt
-        done
-        ;;
-    5)
-        echo "# Commands to remove Mikrotik routes" >> "$output_file"
-        for asn in "${asns[@]}"; do
-            bgpq4 -4 -m 24 -l prefix_list_$asn AS$asn | grep -v '^no ip prefix-list' > tmp_prefixes.txt
-            add_mikrotik_removal
-            rm -f tmp_prefixes.txt
-        done
-        ;;
-    6)
-        echo "# Commands to remove VyOS routes" >> "$output_file"
-        for asn in "${asns[@]}"; do
-            bgpq4 -4 -m 24 -l prefix_list_$asn AS$asn | grep -v '^no ip prefix-list' > tmp_prefixes.txt
-            add_vyos_removal
-            rm -f tmp_prefixes.txt
-        done
-        ;;
-esac
 
 echo "Rotas estáticas geradas em $output_file"
 cat "$output_file"

--- a/run.sh
+++ b/run.sh
@@ -1,63 +1,72 @@
 #!/bin/bash
 
+# Função para detectar o sistema operacional
+detect_os() {
+    case "$(uname -s)" in
+        Darwin)
+            # macOS
+            SED_INLINE="sed -i '' -e"
+            ;;
+        Linux)
+            # Linux
+            SED_INLINE="sed -i -e"
+            ;;
+        *)
+            echo "Sistema operacional não suportado!"
+            exit 1
+            ;;
+    esac
+}
+
 # Função para gerar rotas estáticas para Cisco
 generate_cisco_routes() {
     while read -r prefix; do
-        echo "ip route $prefix Null0" >> $output_file
+        echo "ip route $prefix Null0" >> "$output_file"
     done < tmp_prefixes.txt
-    
-    sed -i 's\ip prefix-list prefix_list_13414 permit\\g' $output_file
 }
 
 # Função para gerar rotas estáticas para Juniper
 generate_juniper_routes() {
     while read -r prefix; do
-        echo "set groups TWITTER-BLOCK routing-options static route $prefix discard" >> $output_file
+        echo "set groups TWITTER-BLOCK routing-options static route $prefix discard" >> "$output_file"
     done < tmp_prefixes.txt
-    echo "set apply-groups TWITTER-BLOCK" >> $output_file
-    
-    sed -i 's\ip prefix-list prefix_list_13414 permit\\g' $output_file
+    echo "set apply-groups TWITTER-BLOCK" >> "$output_file"
 }
 
 # Função para gerar rotas estáticas para Nokia
 generate_nokia_routes() {
     while read -r prefix; do
-        echo "configure router static-route $prefix blackhole" >> $output_file
+        echo "configure router static-route $prefix blackhole" >> "$output_file"
     done < tmp_prefixes.txt
-    
-    sed -i 's\ip prefix-list prefix_list_13414 permit\\g' $output_file
 }
 
 # Função para gerar rotas estáticas para Huawei
 generate_huawei_routes() {
     while read -r prefix; do
-        echo "ip route-static $prefix NULL0" >> $output_file
+        echo "ip route-static $prefix NULL0" >> "$output_file"
     done < tmp_prefixes.txt
-    
-    sed -i 's\ip prefix-list prefix_list_13414 permit\\g' $output_file
-    sed -i 's\/\ \g' $output_file
+    $SED_INLINE 's/\// /g' "$output_file"
 }
 
 # Função para gerar rotas estáticas para Mikrotik
 generate_mikrotik_routes() {
     while read -r prefix; do
-        echo "/ip route add dst-address=$prefix type=blackhole" >> $output_file
+        echo "/ip route add dst-address=$prefix type=blackhole" >> "$output_file"
     done < tmp_prefixes.txt
-    
-    sed -i 's\ip prefix-list prefix_list_13414 permit\\g' $output_file
 }
 
 # Função para gerar rotas estáticas para VyOS
 generate_vyos_routes() {
     while read -r prefix; do
-        echo "set protocols static route $prefix blackhole" >> $output_file
+        echo "set protocols static route $prefix blackhole" >> "$output_file"
     done < tmp_prefixes.txt
-    
-    sed -i 's\ip prefix-list prefix_list_13414 permit\\g' $output_file
 }
 
 # Lista de ASNs
 asns=("63179" "54888" "35995" "13414")
+
+# Detecta o sistema operacional
+detect_os
 
 # Solicita o tipo de dispositivo
 echo "Selecione o fabricante para gerar as rotas estáticas:"
@@ -71,14 +80,14 @@ read -p "Escolha uma opção (1-6): " choice
 
 # Define o arquivo de saída
 output_file="static_routes.txt"
-rm -rf $output_file
+rm -rf "$output_file"
 
 # Limpa o arquivo de saída
-> $output_file
+> "$output_file"
 
 for asn in "${asns[@]}"; do
     # Obtém os prefixos usando bgpq4
-    bgpq4 -4 -m 24 -l prefix_list_$asn AS$asn > tmp_prefixes.txt
+    bgpq4 -4 -m 24 -l prefix_list_$asn AS$asn | grep -v '^no ip prefix-list' > tmp_prefixes.txt
     
     # Gera as rotas com base na escolha
     case $choice in
@@ -106,10 +115,13 @@ for asn in "${asns[@]}"; do
             exit 1
             ;;
     esac
+
+    # Executa o sed para remover as linhas específicas ao ASN atual
+    $SED_INLINE "s/ip prefix-list prefix_list_${asn} permit//g" "$output_file"
     
     # Remove o arquivo temporário
     rm -f tmp_prefixes.txt
 done
 
 echo "Rotas estáticas geradas em $output_file"
-cat $output_file
+cat "$output_file"

--- a/run.sh
+++ b/run.sh
@@ -30,7 +30,6 @@ generate_juniper_routes() {
     while read -r prefix; do
         echo "set groups TWITTER-BLOCK routing-options static route $prefix discard" >> "$output_file"
     done < tmp_prefixes.txt
-    echo "set apply-groups TWITTER-BLOCK" >> "$output_file"
 }
 
 # Função para gerar rotas estáticas para Nokia
@@ -62,6 +61,53 @@ generate_vyos_routes() {
     done < tmp_prefixes.txt
 }
 
+# Função para adicionar comandos de remoção para Cisco
+add_cisco_removal() {
+    echo "# Commands to remove Cisco routes" >> "$output_file"
+    while read -r prefix; do
+        echo "no ip route $prefix Null0" >> "$output_file"
+    done < tmp_prefixes.txt
+}
+
+# Função para adicionar comandos de remoção para Juniper
+add_juniper_removal() {
+    echo "# Commands to remove Juniper routes" >> "$output_file"
+    echo "delete groups TWITTER-BLOCK" >> "$output_file"
+    echo "delete apply-groups TWITTER-BLOCK" >> "$output_file"
+}
+
+# Função para adicionar comandos de remoção para Nokia
+add_nokia_removal() {
+    echo "# Commands to remove Nokia routes" >> "$output_file"
+    while read -r prefix; do
+        echo "no configure router static-route $prefix blackhole" >> "$output_file"
+    done < tmp_prefixes.txt
+}
+
+# Função para adicionar comandos de remoção para Huawei
+add_huawei_removal() {
+    echo "# Commands to remove Huawei routes" >> "$output_file"
+    while read -r prefix; do
+        echo "no ip route-static $prefix NULL0" >> "$output_file"
+    done < tmp_prefixes.txt
+}
+
+# Função para adicionar comandos de remoção para Mikrotik
+add_mikrotik_removal() {
+    echo "# Commands to remove Mikrotik routes" >> "$output_file"
+    while read -r prefix; do
+        echo "/ip route remove dst-address=$prefix" >> "$output_file"
+    done < tmp_prefixes.txt
+}
+
+# Função para adicionar comandos de remoção para VyOS
+add_vyos_removal() {
+    echo "# Commands to remove VyOS routes" >> "$output_file"
+    while read -r prefix; do
+        echo "delete protocols static route $prefix" >> "$output_file"
+    done < tmp_prefixes.txt
+}
+
 # Lista de ASNs
 asns=("63179" "54888" "35995" "13414")
 
@@ -78,9 +124,10 @@ echo "5 - Mikrotik"
 echo "6 - VyOS"
 read -p "Escolha uma opção (1-6): " choice
 
-# Define o arquivo de saída
+# Define os arquivos de saída
 output_file="static_routes.txt"
-rm -rf "$output_file"
+temp_file="juniper_temp.txt"
+rm -rf "$output_file" "$temp_file"
 
 # Limpa o arquivo de saída
 > "$output_file"
@@ -93,21 +140,27 @@ for asn in "${asns[@]}"; do
     case $choice in
         1)
             generate_cisco_routes
+            add_cisco_removal
             ;;
         2)
             generate_juniper_routes
+            # Adiciona o comando apply-groups ao final do arquivo no final
             ;;
         3)
             generate_nokia_routes
+            add_nokia_removal
             ;;
         4)
             generate_huawei_routes
+            add_huawei_removal
             ;;
         5)
             generate_mikrotik_routes
+            add_mikrotik_removal
             ;;
         6)
             generate_vyos_routes
+            add_vyos_removal
             ;;
         *)
             echo "Opção inválida!"
@@ -122,6 +175,12 @@ for asn in "${asns[@]}"; do
     # Remove o arquivo temporário
     rm -f tmp_prefixes.txt
 done
+
+# Adiciona o apply-groups para Juniper no final do arquivo, se necessário
+if [ "$choice" -eq 2 ]; then
+    echo "set apply-groups TWITTER-BLOCK" >> "$output_file"
+    add_juniper_removal
+fi
 
 echo "Rotas estáticas geradas em $output_file"
 cat "$output_file"

--- a/run.sh
+++ b/run.sh
@@ -88,7 +88,7 @@ add_nokia_removal() {
 add_huawei_removal() {
     echo "# Commands to remove Huawei routes" >> "$output_file"
     while read -r prefix; do
-        echo "no ip route-static $prefix NULL0" >> "$output_file"
+        echo "undo ip route-static $prefix NULL0" >> "$output_file"
     done < tmp_prefixes.txt
 }
 


### PR DESCRIPTION
I had problems with macOS because the sed command is different between macOS and Linux. I created a function to detect the OS and adjust the _sed_ command for the two different systems.

I realized that this script generates _no ip prefix-list prefix_list_$asn_ from bgpq4, and I have fixed it.

Now, I see that the script is sometimes adding _set apply-groups TWITTER-BLOCK_ inside the Juniper option. I'm still working on this issue.